### PR TITLE
fix: keep track of the head remote and use that when appropriate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,24 +121,63 @@ fn repo_owner_login(sh: &Shell) -> Result<String> {
     Ok(login.into())
 }
 
-struct PrData {
+struct RemoteGuard<'a> {
+    name: String,
+    shell: &'a Shell,
+}
+
+impl<'a> RemoteGuard<'a> {
+    fn new(shell: &'a Shell, name: String, url: &str) -> Result<Self> {
+        cmd!(shell, "git remote add --no-fetch --no-tags {name} {url}")
+            .run()
+            .context("adding remote")?;
+        Ok(Self { name, shell })
+    }
+}
+
+impl Drop for RemoteGuard<'_> {
+    fn drop(&mut self) {
+        let name = &self.name;
+        let _ = cmd!(&self.shell, "git remote remove {name}").run();
+    }
+}
+
+struct PrData<'a> {
     fork_owner: Option<String>,
+    remote: Option<RemoteGuard<'a>>,
     branch: String,
 }
 
-impl PrData {
-    fn new(fork_owner: Option<&str>, branch: &str) -> Self {
-        Self {
-            fork_owner: fork_owner.map(ToOwned::to_owned),
-            branch: branch.to_owned(),
+impl<'a> PrData<'a> {
+    /// `fork`: `(head_owner, head_repo)`
+    fn new(sh: &'a Shell, fork: Option<(&str, &str)>, branch: &str) -> Result<Self> {
+        let mut remote = None;
+        if let Some((owner, repo)) = fork {
+            let name = owner.to_owned();
+            let url_json = cmd!(sh, "gh repo view {owner}/{repo} --json sshUrl")
+                .quiet()
+                .read()
+                .context("getting foreign ssh url")?;
+            let url_value =
+                serde_json::from_str::<Value>(&url_json).context("parsing foreign ssh url")?;
+            let url = url_value
+                .pointer("/sshUrl")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("malformed foreign ssh url json"))?;
+            remote = Some(RemoteGuard::new(sh, name, url)?);
         }
+
+        let (fork_owner, _fork_repo) = fork.unzip();
+
+        Ok(Self {
+            fork_owner: fork_owner.map(ToOwned::to_owned),
+            remote,
+            branch: branch.to_owned(),
+        })
     }
 
-    fn from_branch(branch: &str) -> Self {
-        Self {
-            fork_owner: None,
-            branch: branch.into(),
-        }
+    fn from_branch(sh: &'a Shell, branch: &str) -> Result<Self> {
+        Self::new(sh, None, branch)
     }
 
     /// Parse a branch or PR number into `Self`
@@ -148,18 +187,18 @@ impl PrData {
     /// - `<integer>`: a PR number
     /// - `<string>`: a branch on the current remote
     /// - `<string>:<string>`: the owner of a fork, followed by the branch on that fork
-    fn parse(sh: &Shell, branch_or_pr_number: &str) -> Result<Self> {
+    fn parse(sh: &'a Shell, branch_or_pr_number: &str) -> Result<Self> {
         if branch_or_pr_number.parse::<u64>().is_ok() {
             let owner = repo_owner_login(sh)?;
             let number = branch_or_pr_number;
             let json = cmd!(
                 sh,
-                "gh pr view {number} --json headRefName,headRepositoryOwner"
+                "gh pr view {number} --json headRefName,headRepository,headRepositoryOwner"
             )
             .quiet()
             .read()
-            .context("getting branch name for pr number")?;
-            let value = serde_json::from_str::<Value>(&json).context("parsing gh branch name")?;
+            .context("getting pr data")?;
+            let value = serde_json::from_str::<Value>(&json).context("parsing pr data")?;
             let branch = value
                 .pointer("/headRefName")
                 .and_then(Value::as_str)
@@ -168,12 +207,25 @@ impl PrData {
                 .pointer("/headRepositoryOwner/login")
                 .and_then(Value::as_str)
                 .ok_or_else(|| anyhow!("malformed response getting head repository owner"))?;
-            let fork_owner = (owner != head_owner).then_some(head_owner);
-            Ok(Self::new(fork_owner, branch))
+            let head_repo = value
+                .pointer("/headRepository/name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("malformed response getting head repo"))?;
+            let fork = (owner != head_owner).then_some((head_owner, head_repo));
+            Self::new(sh, fork, branch)
         } else if let Some((fork_owner, branch)) = branch_or_pr_number.split_once(':') {
-            Ok(Self::new(Some(fork_owner), branch))
+            let json = cmd!(sh, "gh pr view {branch_or_pr_number} --json headRepository")
+                .quiet()
+                .read()
+                .context("getting pr data")?;
+            let value = serde_json::from_str::<Value>(&json).context("parsing pr data")?;
+            let head_repo = value
+                .pointer("/headRepository/name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("malformed response getting head repo"))?;
+            Self::new(sh, Some((fork_owner, head_repo)), branch)
         } else {
-            Ok(Self::from_branch(branch_or_pr_number))
+            Self::from_branch(sh, branch_or_pr_number)
         }
     }
 
@@ -199,13 +251,18 @@ fn main() -> Result<()> {
 
     let pr_data = match (args.branch_or_pr_number, current_branch.as_str()) {
         (None, "main") => bail!("on main; must specify the PR number or branch name to merge"),
-        (None, _) => PrData::from_branch(&current_branch),
+        (None, _) => PrData::from_branch(&sh, &current_branch)?,
         (Some(branch), _) => PrData::parse(&sh, &branch)?,
     };
 
     let branch = &pr_data.branch;
     let qualified_branch = pr_data.qualified_branch();
     let qualified_branch = qualified_branch.as_ref();
+    let head_remote = pr_data
+        .remote
+        .as_ref()
+        .map(|remote| remote.name.as_str())
+        .unwrap_or(&args.remote);
 
     // get review and current ci status
     let status = cmd!(
@@ -245,17 +302,26 @@ fn main() -> Result<()> {
 
     // ensure that the branch is at the tip of its base for a linear history
     let base = status.base_ref_name;
-    cmd!(sh, "git fetch {remote}").run().context("git fetch")?;
-    cmd!(sh, "git checkout {branch}")
+    cmd!(sh, "git fetch --no-all --no-tags {head_remote} {branch}")
+        .run()
+        .context("git fetch")?;
+    // try checking out a local branch
+    if cmd!(sh, "git checkout --no-guess {branch}").run().is_err() {
+        // try checking out a remote branch
+        cmd!(
+            sh,
+            "git checkout --no-guess -b {branch} --track {head_remote}/{branch} --"
+        )
         .run()
         .context("git checkout branch")?;
+    }
 
     // Before we rebase, make sure that the state on the local branch corresponds to the one on
     // remote. Local branch state could differ if there was already a branch that wasn't in sync
     // with the remote. In this case we don't want to do a rebase and `push -f` as that would
     // overwrite the remote branch and merge local state, instead of remote.
-    if !local_branch_matches_remote(&sh, remote, branch)? {
-        bail!("local branch {branch} differs from remote branch {remote}/{branch}");
+    if !local_branch_matches_remote(&sh, head_remote, branch)? {
+        bail!("local branch {branch} differs from remote branch {head_remote}/{branch}");
     }
 
     let rebase_result = cmd!(sh, "git rebase {remote}/{base}").run();
@@ -268,8 +334,8 @@ fn main() -> Result<()> {
 
     // if rebase moved the tip then force-push to ensure github is tracking the new history
     // this resets CI, but doesn't mess with the approvals. We can assume CI is OK, at this point
-    if !local_branch_matches_remote(&sh, remote, branch)? {
-        cmd!(sh, "git push -f {remote} {branch}")
+    if !local_branch_matches_remote(&sh, head_remote, branch)? {
+        cmd!(sh, "git push -f {head_remote} {branch}")
             .run()
             .context("force-pushing branch")?;
     }


### PR DESCRIPTION
This involves temporarily adding a remote to the local repo, removing it when done, and specifying it in appropriate places.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
